### PR TITLE
docker: set become directive for privileged tasks

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: start containerd
+  become: true
   ansible.builtin.service:
     name: containerd
     state: started
@@ -18,20 +19,24 @@
         /usr/share/keyrings/docker-archive-keyring.asc
 
 - name: restart docker
+  become: true
   ansible.builtin.service:
     name: docker
     state: restarted
 
 - name: reload docker
+  become: true
   ansible.builtin.service:
     name: docker
     state: reloaded
 
 - name: validate config  # noqa no-changed-when
+  become: true
   ansible.builtin.command: |
     dockerd --validate
 
 - name: daemon reload
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
     force: true
@@ -45,6 +50,7 @@
     - _changed_docker_configuration.changed
 
 - name: create daemon.json
+  become: true
   bodsch.docker.docker_common_config:
     state: present
     log_driver: "{{ docker_config.log_driver | default(omit) }}"

--- a/roles/docker/tasks/configure.yml
+++ b/roles/docker/tasks/configure.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: create docker config directory
+  become: true
   ansible.builtin.file:
     path: /etc/docker
     state: directory
@@ -19,6 +20,7 @@
     - docker_users | count > 0
 
 - name: manage docker client configuration
+  become: true
   bodsch.docker.docker_client_configs:
     configs: "{{ docker_client_config }}"
   when:
@@ -31,6 +33,7 @@
     - ansible_facts.service_mgr == 'systemd'
   block:
     - name: create dropin directory
+      become: true
       ansible.builtin.file:
         path: "{{ systemd_etc_directory }}/docker.service.d"
         state: "directory"
@@ -39,6 +42,7 @@
         group: root
 
     - name: create systemd dropin to using configuration
+      become: true
       ansible.builtin.template:
         src: systemd/overwrite.conf.j2
         dest: "{{ systemd_etc_directory }}/docker.service.d/overwrite.conf"
@@ -49,6 +53,7 @@
         - daemon reload
 
     - name: create {{ docker_container_prune.name }} run configuration
+      become: true
       ansible.builtin.template:
         src: "{{ docker_container_prune.name }}.j2"
         dest: "{{ docker_defaults_directory }}/{{ docker_container_prune.name }}"
@@ -58,6 +63,7 @@
         mode: "0640"
 
     - name: create systemd service unit {{ docker_container_prune.name }}.service
+      become: true
       ansible.builtin.template:
         src: "systemd/{{ docker_container_prune.name }}.service.j2"
         dest: "{{ systemd_lib_directory }}/{{ docker_container_prune.name }}.service"
@@ -68,6 +74,7 @@
         - daemon reload
 
     - name: create systemd timer unit {{ docker_container_prune.name }}.timer
+      become: true
       ansible.builtin.template:
         src: "systemd/{{ docker_container_prune.name }}.timer.j2"
         dest: "{{ systemd_lib_directory }}/{{ docker_container_prune.name }}.timer"
@@ -78,6 +85,7 @@
         - daemon reload
 
 - name: create openrc config file
+  become: true
   ansible.builtin.template:
     src: openrc/conf.d/docker.j2
     dest: /etc/conf.d/docker
@@ -93,6 +101,7 @@
   ansible.builtin.meta: flush_handlers
 
 - name: create docker config file daemon.json
+  become: true
   bodsch.docker.docker_common_config:
     state: present
     diff_output: "{{ docker_config_diff }}"

--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: remove default packaged docker
+  become: true
   ansible.builtin.package:
     name:
       - docker
@@ -11,11 +12,13 @@
            ansible_facts.os_family | lower | replace(' ', '') == 'artixlinux')
 
 - name: install docker
+  become: true
   ansible.builtin.package:
     name: "{{ docker_packages }}"
     state: "{{ docker_state }}"
 
 - name: create docker run configuration
+  become: true
   ansible.builtin.template:
     src: "docker.j2"
     dest: "{{ docker_defaults_directory }}/docker"
@@ -28,6 +31,7 @@
     - reload docker
 
 - name: ensure containerd is running and enabled on archlinux
+  become: true
   ansible.builtin.service:
     name: containerd
     state: started
@@ -37,6 +41,7 @@
     - ansible_facts.service_mgr | lower == 'systemd'
 
 - name: ensure {{ docker_service.name }} is running
+  become: true
   ansible.builtin.service:
     name: "{{ docker_service.name }}"
     state: started
@@ -61,11 +66,13 @@
     #   # when: "'failed to start daemon' in journalctl_docker.stdout"
 
     - name: ensure {{ docker_service.name }} is stopped
+      become: true
       ansible.builtin.service:
         name: "{{ docker_service.name }}"
         state: stopped
 
     - name: re-create safe docker config file daemon.json
+      become: true
       bodsch.docker.docker_common_config:
         state: present
         diff_output: "{{ docker_config_diff }}"
@@ -87,11 +94,13 @@
         tls_key: "{{ docker_config.tls.key | default(omit) }}"
 
     - name: ensure {{ docker_service.name }} is running
+      become: true
       ansible.builtin.service:
         name: "{{ docker_service.name }}"
         state: started
 
 - name: wait for running docker
+  become: true
   ansible.builtin.wait_for:
     path: /run/docker.pid
     state: present
@@ -100,10 +109,12 @@
     msg: Timeout to find file /run/docker.pid
 
 - name: define docker_version
+  become: true
   bodsch.docker.docker_version:
   register: docker_version
 
 - name: create custom fact file
+  become: true
   bodsch.core.facts:
     name: docker
     facts:

--- a/roles/docker/tasks/plugins.yml
+++ b/roles/docker/tasks/plugins.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: ensure {{ docker_service.name }} is running
+  become: true
   ansible.builtin.service:
     name: "{{ docker_service.name }}"
     state: started
@@ -20,6 +21,7 @@
   register: _plugin_state
 
 - name: install docker plugins
+  become: true
   bodsch.docker.docker_plugins:
     state: present
     plugin_source: "{{ item.source }}"

--- a/roles/docker/tasks/prepare.yml
+++ b/roles/docker/tasks/prepare.yml
@@ -38,6 +38,7 @@
     - not valid_docker_config.valid
 
 - name: install docker dependencies
+  become: true
   ansible.builtin.package:
     name: "{{ docker_dependencies }}"
     state: present
@@ -51,6 +52,7 @@
     - docker_python_packages | count > 0
   block:
     - name: create pip requirements file
+      become: true
       bodsch.core.pip_requirements:
         name: docker
         requirements: "{{ docker_python_packages }}"
@@ -63,6 +65,7 @@
         - not pip_requirements.pip.present
 
     - name: install docker python packages  # noqa no-handler
+      become: true
       ansible.builtin.pip:
         state: present
         requirements: "{{ pip_requirements.requirements_file }}"

--- a/roles/docker/tasks/repositories.yml
+++ b/roles/docker/tasks/repositories.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: add docker-ce apt sources
+  become: true
   when:
     - ansible_facts.os_family | lower == 'debian'
   bodsch.core.apt_sources:

--- a/roles/docker/tasks/service.yml
+++ b/roles/docker/tasks/service.yml
@@ -4,6 +4,7 @@
   ansible.builtin.meta: flush_handlers
 
 - name: ensure {{ docker_service.name }} is running and enabled
+  become: true
   ansible.builtin.service:
     name: "{{ docker_service.name }}"
     state: started
@@ -20,6 +21,7 @@
     #     enabled: "{{ docker_container_prune.enable }}"
 
     - name: "{{ docker_container_prune.name }}.timer"
+      become: true
       ansible.builtin.service:
         name: "{{ docker_container_prune.name }}.timer"
         state: "{{ docker_container_prune.state }}"
@@ -36,6 +38,7 @@
     #     enabled: false
 
     - name: "{{ docker_container_prune.name }}.timer"
+      become: true
       ansible.builtin.service:
         name: "{{ docker_container_prune.name }}.timer"
         state: stopped

--- a/roles/docker/tasks/users.yml
+++ b/roles/docker/tasks/users.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: add users {{ item }} to docker group
+  become: true
   ansible.builtin.user:
     name: "{{ item }}"
     groups: docker
@@ -8,6 +9,7 @@
     state: present
 
 - name: sets ACL for {{ item }} on /run/docker.sock
+  become: true
   ansible.posix.acl:
     path: /run/docker.sock
     entity: "{{ item }}"


### PR DESCRIPTION
This drops the consumer requirement of setting the entire play to be run as root, which doesn't work in some scenarios.

Fixes #8.